### PR TITLE
Fix/jq binary platform and version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-jq",
     "displayName": "vscode-jq",
     "description": "jq plugin for Visual Studio Code",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "publisher": "dandric",
     "icon": "images/icon.png",
     "keywords": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,9 +25,9 @@ import * as child_process from 'child_process';
 
 const OUTPUT_NAME = 'jq output';
 const BINARIES = {
-    'windows': 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win64.exe',
-    'mac': 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64',
-    'linux': 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64'
+    'windows': 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-win64.exe',
+    'mac': 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64',
+    'linux': 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64'
 };
 const BIN_DIR = path.join(__dirname, '..', 'bin')
 const FILEPATH = path.join(BIN_DIR, /^win/.test(process.platform) ? './jq.exe' : './jq');


### PR DESCRIPTION
Updates jq version, and will remove binary from vsce publish. 

https://github.com/andricDu/vscode-jq/issues/8